### PR TITLE
Refactor DepositStakeQuoteArgs to remove redundant data

### DIFF
--- a/core/src/state/pool.rs
+++ b/core/src/state/pool.rs
@@ -235,16 +235,20 @@ impl StakePool {
     pub fn quote_deposit_stake(
         &self,
         stake_account_lamports: StakeAccountLamports,
-        args: DepositStakeQuoteArgs,
+        DepositStakeQuoteArgs {
+            validator_status,
+            validator_vote,
+            current_epoch,
+        }: &DepositStakeQuoteArgs,
     ) -> Result<DepositStakeQuote, SplStakePoolError> {
-        if !self.is_updated_for_epoch(args.current_epoch) {
+        if !self.is_updated_for_epoch(*current_epoch) {
             return Err(SplStakePoolError::StakeListAndPoolOutOfDate);
         }
 
-        if !self.can_deposit_stake_of(&args.validator) {
+        if !self.can_deposit_stake_of(validator_vote) {
             return Err(SplStakePoolError::IncorrectDepositVoteAddress);
         }
-        if args.validator_stake_info.status() != StakeStatus::Active {
+        if *validator_status != StakeStatus::Active {
             return Err(SplStakePoolError::InvalidState);
         }
 

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -1,6 +1,6 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 
-use crate::{ValidatorStakeInfo, STAKE_ACCOUNT_RENT_EXEMPT_LAMPORTS};
+use crate::{StakeStatus, ValidatorStakeInfo, STAKE_ACCOUNT_RENT_EXEMPT_LAMPORTS};
 
 #[derive(Debug, Clone, Copy, BorshSerialize, BorshDeserialize)]
 #[cfg_attr(
@@ -44,24 +44,25 @@ impl DepositSolQuote {
     }
 }
 
-#[derive(Debug, Clone, Copy, BorshSerialize, BorshDeserialize)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "camelCase")
-)]
-#[cfg_attr(
-    feature = "wasm",
-    derive(tsify_next::Tsify),
-    tsify(into_wasm_abi, from_wasm_abi, large_number_types_as_bigints)
-)]
-pub struct DepositStakeQuoteArgs {
-    pub validator_stake_info: ValidatorStakeInfo,
-    pub validator: [u8; 32],
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DepositStakeQuoteArgs<'a> {
+    pub validator_status: StakeStatus,
+    pub validator_vote: &'a [u8; 32],
     pub current_epoch: u64,
 }
 
-#[derive(Debug, Clone, Copy, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
+impl<'a> DepositStakeQuoteArgs<'a> {
+    #[inline]
+    pub fn new(vsi: &'a ValidatorStakeInfo, current_epoch: u64) -> Self {
+        Self {
+            validator_status: vsi.status(),
+            validator_vote: vsi.vote_account_address(),
+            current_epoch,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde",
     derive(serde::Serialize, serde::Deserialize),


### PR DESCRIPTION
`vote` was duplicated between `ValidatorStakeInfo` and struct field.

Now, new struct only takes in exactly the data it requires, while providing a `new()` convenience fn for creating it from `ValidatorStakeInfo`