### PR TITLE
Add `ValidatorNotFound` and `InvalidStakeDepositAuthority` error enum variants

### DIFF
--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -5,9 +5,11 @@ pub enum SplStakePoolError {
     CalculationFailure,
     IncorrectDepositVoteAddress,
     InvalidSolDepositAuthority,
+    InvalidStakeDepositAuthority,
     InvalidState,
     SolWithdrawalTooLarge,
     StakeListAndPoolOutOfDate,
+    ValidatorNotFound,
 }
 
 impl Display for SplStakePoolError {


### PR DESCRIPTION
To enable downstream consumers to better handle quote deposit stake errors