### PR TITLE
Feat: quote_rev_deposit_stake

### DIFF
--- a/core/src/state/pool.rs
+++ b/core/src/state/pool.rs
@@ -336,14 +336,17 @@ impl StakePool {
     }
 
     /// Reverse of [`Self::quote_deposit_stake_unchecked`]: given a target
-    /// `tokens_out` and fixed `unstaked_lamports`, returns the minimum staked
-    /// lamports required to receive at least `tokens_out` pool tokens.
+    /// `tokens_out` and fixed `unstaked_lamports`, returns a conservative
+    /// staked lamports amount sufficient to receive at least `tokens_out` pool tokens.
     ///
-    /// Returns `None` on arithmetic overflow, if `tokens_out` is unachievable,
-    /// or if either `stake_deposit_fee` or `sol_deposit_fee` is non-zero.
-    /// Non-zero fees have no closed-form inverse (the unstaked token contribution
-    /// `floor((staked+u)*r) - floor(staked*r)` is non-monotonic in `staked`),
-    /// and binary search is also incorrect for the same reason.
+    /// Returns `None` on arithmetic overflow or if `tokens_out` is unachievable.
+    ///
+    /// For zero deposit fees, this returns the exact minimum. For nonzero fees,
+    /// this is conservative and may overestimate because it ignores combined
+    /// `staked + unstaked` rounding. The overestimate is at most the staked
+    /// lamports needed for one pool-token base unit after stake fees. This returns
+    /// `None` when a positive staked contribution is required but
+    /// `stake_deposit_fee` is effectively 100%.
     ///
     /// NB: returned quote might not be applicable if:
     /// - pool has not been updated for the current epoch
@@ -357,22 +360,34 @@ impl StakePool {
         tokens_out: u64,
         unstaked_lamports: u64,
     ) -> Option<DepositStakeQuote> {
-        // No closed-form inverse and binary search both fail for non-zero fees
-        // See doc comment
-        if !self.stake_deposit_fee.is_zero() || !self.sol_deposit_fee.is_zero() {
-            return None;
-        }
-
-        let quote_for_staked = |staked| {
-            self.quote_deposit_stake_unchecked(StakeAccountLamports {
+        if self.stake_deposit_fee.is_zero() && self.sol_deposit_fee.is_zero() {
+            let min_total_lamports = *self.rev_lamports_to_pool_tokens(tokens_out)?.start();
+            let staked = min_total_lamports.saturating_sub(unstaked_lamports);
+            let quote = self.quote_deposit_stake_unchecked(StakeAccountLamports {
                 staked,
                 unstaked: unstaked_lamports,
-            })
-        };
+            })?;
+            return (quote.tokens_out >= tokens_out).then_some(quote);
+        }
 
-        let min_total_lamports = *self.rev_lamports_to_pool_tokens(tokens_out)?.start();
-        let staked = min_total_lamports.saturating_sub(unstaked_lamports);
-        let quote = quote_for_staked(staked)?;
+        let stake_fee = self.stake_deposit_fee.to_fee_ceil()?;
+        let sol_fee = self.sol_deposit_fee.to_fee_ceil()?;
+
+        // Use the token value of unstaked lamports alone as a conservative lower
+        // bound. The actual deposit may receive one extra pool-token base unit
+        // from combined staked + unstaked floor rounding, so this can overestimate
+        // by amount of SOL lamports required for the 1 additional pool token.
+        let sol_tokens_lo = self.lamports_to_pool_tokens(unstaked_lamports)?;
+        let sol_after_fee_lo = sol_fee.apply(sol_tokens_lo)?.rem();
+        let required_stake_after_fee = tokens_out.saturating_sub(sol_after_fee_lo);
+        let stake_tokens = *stake_fee
+            .reverse_from_rem(required_stake_after_fee)?
+            .start();
+        let staked = *self.rev_lamports_to_pool_tokens(stake_tokens)?.start();
+        let quote = self.quote_deposit_stake_unchecked(StakeAccountLamports {
+            staked,
+            unstaked: unstaked_lamports,
+        })?;
         (quote.tokens_out >= tokens_out).then_some(quote)
     }
 

--- a/core/src/state/pool.rs
+++ b/core/src/state/pool.rs
@@ -335,11 +335,15 @@ impl StakePool {
             .ok_or(SplStakePoolError::CalculationFailure)
     }
 
-    /// Reverse of [`Self::quote_deposit_stake_unchecked`]: returns the quote for
-    /// the minimum staked lamports required to receive at least `tokens_out` pool
-    /// tokens, given fixed unstaked lamports already in the stake account.
+    /// Reverse of [`Self::quote_deposit_stake_unchecked`]: given a target
+    /// `tokens_out` and fixed `unstaked_lamports`, returns the minimum staked
+    /// lamports required to receive at least `tokens_out` pool tokens.
     ///
-    /// Returns `None` on arithmetic overflow or if `tokens_out` is unachievable.
+    /// Returns `None` on arithmetic overflow, if `tokens_out` is unachievable,
+    /// or if either `stake_deposit_fee` or `sol_deposit_fee` is non-zero.
+    /// Non-zero fees have no closed-form inverse (the unstaked token contribution
+    /// `floor((staked+u)*r) - floor(staked*r)` is non-monotonic in `staked`),
+    /// and binary search is also incorrect for the same reason.
     ///
     /// NB: returned quote might not be applicable if:
     /// - pool has not been updated for the current epoch
@@ -353,6 +357,12 @@ impl StakePool {
         tokens_out: u64,
         unstaked_lamports: u64,
     ) -> Option<DepositStakeQuote> {
+        // No closed-form inverse and binary search both fail for non-zero fees
+        // See doc comment
+        if !self.stake_deposit_fee.is_zero() || !self.sol_deposit_fee.is_zero() {
+            return None;
+        }
+
         let quote_for_staked = |staked| {
             self.quote_deposit_stake_unchecked(StakeAccountLamports {
                 staked,
@@ -360,40 +370,10 @@ impl StakePool {
             })
         };
 
-        if self.stake_deposit_fee.is_zero() && self.sol_deposit_fee.is_zero() {
-            let min_total_lamports = *self.rev_lamports_to_pool_tokens(tokens_out)?.start();
-            let staked = min_total_lamports.saturating_sub(unstaked_lamports);
-            let quote = quote_for_staked(staked)?;
-            return (quote.tokens_out >= tokens_out).then_some(quote);
-        }
-
-        let mut lo = 0;
-        let mut hi = u64::MAX.checked_sub(unstaked_lamports)?;
-        let mut best = None;
-
-        while lo <= hi {
-            let mid = lo + (hi - lo) / 2;
-            match quote_for_staked(mid) {
-                Some(quote) if quote.tokens_out >= tokens_out => {
-                    best = Some(quote);
-                    if mid == 0 {
-                        break;
-                    }
-                    hi = mid - 1;
-                }
-                Some(_) => {
-                    lo = mid.checked_add(1)?;
-                }
-                None => {
-                    if mid == 0 {
-                        break;
-                    }
-                    hi = mid - 1;
-                }
-            }
-        }
-
-        best
+        let min_total_lamports = *self.rev_lamports_to_pool_tokens(tokens_out)?.start();
+        let staked = min_total_lamports.saturating_sub(unstaked_lamports);
+        let quote = quote_for_staked(staked)?;
+        (quote.tokens_out >= tokens_out).then_some(quote)
     }
 
     /// Performs the checks needed to be serviceable along with calculation logic

--- a/core/src/state/pool.rs
+++ b/core/src/state/pool.rs
@@ -5,9 +5,10 @@ use sanctum_u64_ratio::{Floor, Ratio};
 
 use crate::{
     reserve_has_sufficient_lamports, AccountType, DepositSolQuote, DepositSolQuoteArgs,
-    DepositStakeQuote, DepositStakeQuoteArgs, Fee, FutureEpoch, Lockup, ReferralFee,
-    SplStakePoolError, StakeAccountLamports, StakeStatus, WithdrawSolQuote, WithdrawSolQuoteArgs,
-    WithdrawStakeQuote, WithdrawStakeQuoteArgs,
+    DepositStakeQuote, DepositStakeQuoteArgs, Fee, FutureEpoch, Lockup, QuoteRevDepositStakeArgs,
+    ReferralFee, SplStakePoolError, StakeAccountLamports, StakeStatus, WithdrawSolQuote,
+    WithdrawSolQuoteArgs, WithdrawStakeQuote, WithdrawStakeQuoteArgs,
+    STAKE_ACCOUNT_RENT_EXEMPT_LAMPORTS,
 };
 
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize)]
@@ -276,7 +277,7 @@ impl StakePool {
         &self,
         stake_account_lamports: StakeAccountLamports,
     ) -> Option<DepositStakeQuote> {
-        let new_pool_tokens = self.lamports_to_pool_tokens(stake_account_lamports.total())?;
+        let new_pool_tokens = self.lamports_to_pool_tokens(stake_account_lamports.total()?)?;
         let new_pool_tokens_from_stake =
             self.lamports_to_pool_tokens(stake_account_lamports.staked)?;
         let new_pool_tokens_from_sol = new_pool_tokens.checked_sub(new_pool_tokens_from_stake)?;
@@ -309,8 +310,10 @@ impl StakePool {
     #[inline]
     pub fn quote_rev_deposit_stake(
         &self,
-        tokens_out: u64,
-        unstaked_lamports: u64,
+        QuoteRevDepositStakeArgs {
+            tokens_out,
+            unstaked_lamports,
+        }: QuoteRevDepositStakeArgs,
         DepositStakeQuoteArgs {
             validator_status,
             validator_vote,
@@ -331,8 +334,11 @@ impl StakePool {
             return Err(SplStakePoolError::InvalidStakeDepositAuthority);
         }
 
-        self.quote_rev_deposit_stake_unchecked(tokens_out, unstaked_lamports)
-            .ok_or(SplStakePoolError::CalculationFailure)
+        self.quote_rev_deposit_stake_unchecked(QuoteRevDepositStakeArgs {
+            tokens_out,
+            unstaked_lamports,
+        })
+        .ok_or(SplStakePoolError::CalculationFailure)
     }
 
     /// Reverse of [`Self::quote_deposit_stake_unchecked`]: given a target
@@ -341,8 +347,7 @@ impl StakePool {
     ///
     /// Returns `None` on arithmetic overflow or if `tokens_out` is unachievable.
     ///
-    /// For zero deposit fees, this returns the exact minimum. For nonzero fees,
-    /// this is conservative and may overestimate because it ignores combined
+    /// This is conservative and may overestimate because it ignores combined
     /// `staked + unstaked` rounding. The overestimate is at most the staked
     /// lamports needed for one pool-token base unit after stake fees. This returns
     /// `None` when a positive staked contribution is required but
@@ -357,19 +362,12 @@ impl StakePool {
     #[inline]
     pub fn quote_rev_deposit_stake_unchecked(
         &self,
-        tokens_out: u64,
-        unstaked_lamports: u64,
+        QuoteRevDepositStakeArgs {
+            tokens_out,
+            unstaked_lamports,
+        }: QuoteRevDepositStakeArgs,
     ) -> Option<DepositStakeQuote> {
-        if self.stake_deposit_fee.is_zero() && self.sol_deposit_fee.is_zero() {
-            let min_total_lamports = *self.rev_lamports_to_pool_tokens(tokens_out)?.start();
-            let staked = min_total_lamports.saturating_sub(unstaked_lamports);
-            let quote = self.quote_deposit_stake_unchecked(StakeAccountLamports {
-                staked,
-                unstaked: unstaked_lamports,
-            })?;
-            return (quote.tokens_out >= tokens_out).then_some(quote);
-        }
-
+        let unstaked_lamports = unstaked_lamports.unwrap_or(STAKE_ACCOUNT_RENT_EXEMPT_LAMPORTS);
         let stake_fee = self.stake_deposit_fee.to_fee_ceil()?;
         let sol_fee = self.sol_deposit_fee.to_fee_ceil()?;
 

--- a/core/src/state/pool.rs
+++ b/core/src/state/pool.rs
@@ -310,10 +310,7 @@ impl StakePool {
     #[inline]
     pub fn quote_rev_deposit_stake(
         &self,
-        QuoteRevDepositStakeArgs {
-            tokens_out,
-            unstaked_lamports,
-        }: QuoteRevDepositStakeArgs,
+        args: QuoteRevDepositStakeArgs,
         DepositStakeQuoteArgs {
             validator_status,
             validator_vote,
@@ -334,11 +331,8 @@ impl StakePool {
             return Err(SplStakePoolError::InvalidStakeDepositAuthority);
         }
 
-        self.quote_rev_deposit_stake_unchecked(QuoteRevDepositStakeArgs {
-            tokens_out,
-            unstaked_lamports,
-        })
-        .ok_or(SplStakePoolError::CalculationFailure)
+        self.quote_rev_deposit_stake_unchecked(args)
+            .ok_or(SplStakePoolError::CalculationFailure)
     }
 
     /// Reverse of [`Self::quote_deposit_stake_unchecked`]: given a target
@@ -348,9 +342,13 @@ impl StakePool {
     /// Returns `None` on arithmetic overflow or if `tokens_out` is unachievable.
     ///
     /// This is conservative and may overestimate because it ignores combined
-    /// `staked + unstaked` rounding. The overestimate is at most the staked
-    /// lamports needed for one pool-token base unit after stake fees. This returns
-    /// `None` when a positive staked contribution is required but
+    /// `staked + unstaked` floor rounding. The output `tokens_out` can exceed
+    /// the requested amount by at most `floor(pool_token_supply / total_lamports) + 1`
+    /// - `floor(pool_token_supply / total_lamports)` from `rev_lamports_to_pool_tokens`
+    ///   landing on a skipped pool-token value in ratio-lte-one pools
+    /// - `1` from the conservative `sol_lo` estimate
+    ///
+    /// Returns `None` when a positive staked contribution is required but
     /// `stake_deposit_fee` is effectively 100%.
     ///
     /// NB: returned quote might not be applicable if:

--- a/core/src/state/pool.rs
+++ b/core/src/state/pool.rs
@@ -307,6 +307,97 @@ impl StakePool {
 
     /// Performs the checks needed to be serviceable along with calculation logic
     #[inline]
+    pub fn quote_rev_deposit_stake(
+        &self,
+        tokens_out: u64,
+        unstaked_lamports: u64,
+        DepositStakeQuoteArgs {
+            validator_status,
+            validator_vote,
+            current_epoch,
+            depositor,
+        }: &DepositStakeQuoteArgs,
+    ) -> Result<DepositStakeQuote, SplStakePoolError> {
+        if !self.is_updated_for_epoch(*current_epoch) {
+            return Err(SplStakePoolError::StakeListAndPoolOutOfDate);
+        }
+        if !self.can_deposit_stake_of(validator_vote) {
+            return Err(SplStakePoolError::IncorrectDepositVoteAddress);
+        }
+        if *validator_status != StakeStatus::Active {
+            return Err(SplStakePoolError::InvalidState);
+        }
+        if depositor.is_some_and(|d| *d != self.stake_deposit_authority) {
+            return Err(SplStakePoolError::InvalidStakeDepositAuthority);
+        }
+
+        self.quote_rev_deposit_stake_unchecked(tokens_out, unstaked_lamports)
+            .ok_or(SplStakePoolError::CalculationFailure)
+    }
+
+    /// Reverse of [`Self::quote_deposit_stake_unchecked`]: returns the quote for
+    /// the minimum staked lamports required to receive at least `tokens_out` pool
+    /// tokens, given fixed unstaked lamports already in the stake account.
+    ///
+    /// Returns `None` on arithmetic overflow or if `tokens_out` is unachievable.
+    ///
+    /// NB: returned quote might not be applicable if:
+    /// - pool has not been updated for the current epoch
+    /// - selected validator is not active
+    /// - selected validator has insufficient stake
+    /// - selected validator is not in the validator list
+    /// - selected validator is not the preferred validator
+    #[inline]
+    pub fn quote_rev_deposit_stake_unchecked(
+        &self,
+        tokens_out: u64,
+        unstaked_lamports: u64,
+    ) -> Option<DepositStakeQuote> {
+        let quote_for_staked = |staked| {
+            self.quote_deposit_stake_unchecked(StakeAccountLamports {
+                staked,
+                unstaked: unstaked_lamports,
+            })
+        };
+
+        if self.stake_deposit_fee.is_zero() && self.sol_deposit_fee.is_zero() {
+            let min_total_lamports = *self.rev_lamports_to_pool_tokens(tokens_out)?.start();
+            let staked = min_total_lamports.saturating_sub(unstaked_lamports);
+            let quote = quote_for_staked(staked)?;
+            return (quote.tokens_out >= tokens_out).then_some(quote);
+        }
+
+        let mut lo = 0;
+        let mut hi = u64::MAX.checked_sub(unstaked_lamports)?;
+        let mut best = None;
+
+        while lo <= hi {
+            let mid = lo + (hi - lo) / 2;
+            match quote_for_staked(mid) {
+                Some(quote) if quote.tokens_out >= tokens_out => {
+                    best = Some(quote);
+                    if mid == 0 {
+                        break;
+                    }
+                    hi = mid - 1;
+                }
+                Some(_) => {
+                    lo = mid.checked_add(1)?;
+                }
+                None => {
+                    if mid == 0 {
+                        break;
+                    }
+                    hi = mid - 1;
+                }
+            }
+        }
+
+        best
+    }
+
+    /// Performs the checks needed to be serviceable along with calculation logic
+    #[inline]
     pub fn quote_withdraw_sol(
         &self,
         pool_tokens: u64,
@@ -565,6 +656,21 @@ impl StakePool {
             return Some(lamports);
         }
         ratio.apply(lamports)
+    }
+
+    /// Given output `pool_tokens`, return range of `lamports`
+    /// that may have been fed into [`Self::lamports_to_pool_tokens`]
+    /// This may yield a different result from [`Self::pool_tokens_to_lamports`]
+    #[inline]
+    pub const fn rev_lamports_to_pool_tokens(
+        &self,
+        pool_tokens: u64,
+    ) -> Option<RangeInclusive<u64>> {
+        let ratio = self.supply_over_lamports();
+        if ratio.0.is_zero() {
+            return Some(pool_tokens..=pool_tokens);
+        }
+        ratio.reverse_est(pool_tokens)
     }
 
     /// Returns the number of lamports equivalent to `pool tokens`

--- a/core/src/typedefs/fee.rs
+++ b/core/src/typedefs/fee.rs
@@ -24,11 +24,6 @@ impl Fee {
     };
 
     #[inline]
-    pub const fn is_zero(&self) -> bool {
-        self.numerator == 0 || self.denominator == 0
-    }
-
-    #[inline]
     pub const fn to_fee_ceil(&self) -> Option<F> {
         // The SPL stake pool program permits denominator to = 0
         // (treated as 0 fee in that case)

--- a/core/src/typedefs/fee.rs
+++ b/core/src/typedefs/fee.rs
@@ -24,6 +24,11 @@ impl Fee {
     };
 
     #[inline]
+    pub const fn is_zero(&self) -> bool {
+        self.numerator == 0 || self.denominator == 0
+    }
+
+    #[inline]
     pub const fn to_fee_ceil(&self) -> Option<F> {
         // The SPL stake pool program permits denominator to = 0
         // (treated as 0 fee in that case)

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -146,6 +146,13 @@ pub struct WithdrawStakeQuoteArgs {
     pub current_epoch: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QuoteRevDepositStakeArgs {
+    pub tokens_out: u64,
+    /// `None` defaults to `STAKE_ACCOUNT_RENT_EXEMPT_LAMPORTS`
+    pub unstaked_lamports: Option<u64>,
+}
+
 #[derive(Debug, Clone, Copy, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde",
@@ -182,8 +189,8 @@ pub struct StakeAccountLamports {
 }
 
 impl StakeAccountLamports {
-    pub fn total(&self) -> u64 {
-        self.staked + self.unstaked
+    pub fn total(&self) -> Option<u64> {
+        self.staked.checked_add(self.unstaked)
     }
 }
 

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -147,6 +147,16 @@ pub struct WithdrawStakeQuoteArgs {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase")
+)]
+#[cfg_attr(
+    feature = "wasm",
+    derive(tsify_next::Tsify),
+    tsify(into_wasm_abi, from_wasm_abi, large_number_types_as_bigints)
+)]
 pub struct QuoteRevDepositStakeArgs {
     pub tokens_out: u64,
     /// `None` defaults to `STAKE_ACCOUNT_RENT_EXEMPT_LAMPORTS`

--- a/core/tests/tests/quote/deposit_stake.rs
+++ b/core/tests/tests/quote/deposit_stake.rs
@@ -1,6 +1,15 @@
-use sanctum_spl_stake_pool_core::{DepositStakeQuote, Fee, StakeAccountLamports, StakePool};
+use proptest::prelude::*;
+use sanctum_spl_stake_pool_core::{
+    DepositStakeQuote, Fee, QuoteRevDepositStakeArgs, StakeAccountLamports, StakePool,
+};
+use sanctum_u64_ratio::Ratio;
 
-fn assert_sufficient_and_minimal(sp: &StakePool, quote: DepositStakeQuote, requested: u64) {
+use crate::common::{
+    proptest_utils::{ratio_gte_one, ratio_lte_one},
+    quote::{NewPoolQuoteU64sBuilder, PoolQuoteU64Ds},
+};
+
+fn assert_sufficient(sp: &StakePool, quote: DepositStakeQuote, requested: u64) {
     assert_eq!(
         sp.quote_deposit_stake_unchecked(quote.stake_account_lamports_in),
         Some(quote)
@@ -11,74 +20,193 @@ fn assert_sufficient_and_minimal(sp: &StakePool, quote: DepositStakeQuote, reque
         quote.tokens_out,
         requested
     );
+}
 
-    if quote.stake_account_lamports_in.staked == 0 {
+fn quote_rev_deposit_stake_round_trip(
+    pool: PoolQuoteU64Ds,
+    staked: u64,
+    unstaked: u64,
+    stake_deposit_fee: Fee,
+    sol_deposit_fee: Fee,
+) {
+    // to_fee_ceil() returns None for fees > 100%, which the reverse requires
+    // but the forward does not. Skip those cases rather than treating None as a bug
+    if stake_deposit_fee.to_fee_ceil().is_none() || sol_deposit_fee.to_fee_ceil().is_none() {
         return;
     }
 
-    let previous = StakeAccountLamports {
-        staked: quote.stake_account_lamports_in.staked - 1,
-        unstaked: quote.stake_account_lamports_in.unstaked,
+    let sp = StakePool {
+        total_lamports: *pool.total_lamports(),
+        pool_token_supply: *pool.pool_token_supply(),
+        stake_deposit_fee,
+        sol_deposit_fee,
+        ..Default::default()
     };
-    if let Some(previous_quote) = sp.quote_deposit_stake_unchecked(previous) {
-        assert!(
-            previous_quote.tokens_out < requested,
-            "previous staked lamports still satisfied target: {:?}",
-            previous_quote
+
+    let Some(forward) = sp.quote_deposit_stake_unchecked(StakeAccountLamports { staked, unstaked })
+    else {
+        return;
+    };
+
+    let rev = sp
+        .quote_rev_deposit_stake_unchecked(QuoteRevDepositStakeArgs {
+            tokens_out: forward.tokens_out,
+            unstaked_lamports: Some(unstaked),
+        })
+        .expect("reverse returned None but forward succeeded with valid fees");
+
+    assert_eq!(rev.stake_account_lamports_in.unstaked, unstaked);
+    assert_sufficient(&sp, rev, forward.tokens_out);
+}
+
+// verifies the floor arithmetic bound relied on by `quote_rev_deposit_stake_unchecked`:
+// the token value of unstaked lamports in a combined deposit is at most unstaked_tokens_alone + 1
+fn assert_unstaked_token_bucket_bound(
+    pool: PoolQuoteU64Ds,
+    staked: u64,
+    unstaked: u64,
+    sol_deposit_fee: Fee,
+) {
+    // mimics behaviour in quote_deposit_stake_unchecked
+    // where StakeAccountLamports.total() overflows u64
+    let Some(total) = staked.checked_add(unstaked) else {
+        return;
+    };
+
+    let sp = StakePool {
+        total_lamports: *pool.total_lamports(),
+        pool_token_supply: *pool.pool_token_supply(),
+        sol_deposit_fee,
+        ..Default::default()
+    };
+
+    let Some(new_pool_tokens) = sp.lamports_to_pool_tokens(total) else {
+        return;
+    };
+    let Some(new_pool_tokens_from_stake) = sp.lamports_to_pool_tokens(staked) else {
+        return;
+    };
+    let Some(actual_unstaked_tokens) = new_pool_tokens.checked_sub(new_pool_tokens_from_stake)
+    else {
+        return;
+    };
+    let Some(unstaked_tokens_alone) = sp.lamports_to_pool_tokens(unstaked) else {
+        return;
+    };
+
+    assert!(
+        actual_unstaked_tokens == unstaked_tokens_alone
+            || actual_unstaked_tokens == unstaked_tokens_alone + 1,
+        "actual_unstaked_tokens={actual_unstaked_tokens}, unstaked_tokens_alone={unstaked_tokens_alone}"
+    );
+
+    let Some(fee) = sol_deposit_fee.to_fee_ceil() else {
+        return;
+    };
+    let Some(actual_after_fee) = fee.apply(actual_unstaked_tokens).map(|x| x.rem()) else {
+        return;
+    };
+    let Some(alone_after_fee) = fee.apply(unstaked_tokens_alone).map(|x| x.rem()) else {
+        return;
+    };
+    assert!(actual_after_fee >= alone_after_fee);
+    assert!(actual_after_fee <= alone_after_fee + 1);
+}
+
+proptest! {
+    #[test]
+    fn quote_rev_deposit_stake_round_trip_x_gte_1_pt(
+        Ratio {
+            n: total_lamports,
+            d: pool_token_supply,
+        } in ratio_gte_one(),
+        staked: u64,
+        unstaked: u64,
+        stake_fee_n: u64,
+        stake_fee_d: u64,
+        sol_fee_n: u64,
+        sol_fee_d: u64,
+    ) {
+        quote_rev_deposit_stake_round_trip(
+            NewPoolQuoteU64sBuilder::start()
+                .with_total_lamports(total_lamports)
+                .with_pool_token_supply(pool_token_supply)
+                .build(),
+            staked,
+            unstaked,
+            Fee { numerator: stake_fee_n, denominator: stake_fee_d },
+            Fee { numerator: sol_fee_n, denominator: sol_fee_d },
         );
     }
-}
 
-#[test]
-fn quote_rev_deposit_stake_zero_fee_direct_path() {
-    let sp = StakePool {
-        total_lamports: 1_000_000_000_000,
-        pool_token_supply: 900_000_000_000,
-        stake_deposit_fee: Fee::ZERO,
-        sol_deposit_fee: Fee::ZERO,
-        ..Default::default()
-    };
-    let requested = 90_000_000;
-    let unstaked = 2_282_880;
+    #[test]
+    fn quote_rev_deposit_stake_round_trip_x_lte_1_pt(
+        Ratio {
+            n: total_lamports,
+            d: pool_token_supply,
+        } in ratio_lte_one(),
+        staked: u64,
+        unstaked: u64,
+        stake_fee_n: u64,
+        stake_fee_d: u64,
+        sol_fee_n: u64,
+        sol_fee_d: u64,
+    ) {
+        quote_rev_deposit_stake_round_trip(
+            NewPoolQuoteU64sBuilder::start()
+                .with_total_lamports(total_lamports)
+                .with_pool_token_supply(pool_token_supply)
+                .build(),
+            staked,
+            unstaked,
+            Fee { numerator: stake_fee_n, denominator: stake_fee_d },
+            Fee { numerator: sol_fee_n, denominator: sol_fee_d },
+        );
+    }
 
-    let quote = sp
-        .quote_rev_deposit_stake_unchecked(requested, unstaked)
-        .unwrap();
+    #[test]
+    fn deposit_stake_unstaked_token_bucket_bound_x_gte_1_pt(
+        Ratio {
+            n: total_lamports,
+            d: pool_token_supply,
+        } in ratio_gte_one(),
+        staked: u64,
+        unstaked: u64,
+        sol_fee_n: u64,
+        sol_fee_d: u64,
+    ) {
+        assert_unstaked_token_bucket_bound(
+            NewPoolQuoteU64sBuilder::start()
+                .with_total_lamports(total_lamports)
+                .with_pool_token_supply(pool_token_supply)
+                .build(),
+            staked,
+            unstaked,
+            Fee { numerator: sol_fee_n, denominator: sol_fee_d },
+        );
+    }
 
-    assert_eq!(quote.stake_account_lamports_in.unstaked, unstaked);
-    assert_eq!(quote.manager_fee, 0);
-    assert_eq!(quote.referral_fee, 0);
-    assert_sufficient_and_minimal(&sp, quote, requested);
-}
-
-#[test]
-fn quote_rev_deposit_stake_nonzero_fees_returns_sufficient_quote() {
-    let sp = StakePool {
-        total_lamports: 1_000_000_000_000,
-        pool_token_supply: 900_000_000_000,
-        stake_deposit_fee: Fee {
-            numerator: 3,
-            denominator: 1_000,
-        },
-        sol_deposit_fee: Fee {
-            numerator: 7,
-            denominator: 1_000,
-        },
-        ..Default::default()
-    };
-    let requested = 90_000_000;
-    let unstaked = 2_282_880;
-
-    let quote = sp
-        .quote_rev_deposit_stake_unchecked(requested, unstaked)
-        .unwrap();
-
-    assert_eq!(quote.stake_account_lamports_in.unstaked, unstaked);
-    assert_eq!(
-        sp.quote_deposit_stake_unchecked(quote.stake_account_lamports_in),
-        Some(quote)
-    );
-    assert!(quote.tokens_out >= requested);
+    #[test]
+    fn deposit_stake_unstaked_token_bucket_bound_x_lte_1_pt(
+        Ratio {
+            n: total_lamports,
+            d: pool_token_supply,
+        } in ratio_lte_one(),
+        staked: u64,
+        unstaked: u64,
+        sol_fee_n: u64,
+        sol_fee_d: u64,
+    ) {
+        assert_unstaked_token_bucket_bound(
+            NewPoolQuoteU64sBuilder::start()
+                .with_total_lamports(total_lamports)
+                .with_pool_token_supply(pool_token_supply)
+                .build(),
+            staked,
+            unstaked,
+            Fee { numerator: sol_fee_n, denominator: sol_fee_d },
+        );
+    }
 }
 
 #[test]
@@ -93,7 +221,12 @@ fn quote_rev_deposit_stake_when_unstaked_covers_target_returns_zero_staked() {
         sol_deposit_fee: Fee::ZERO,
         ..Default::default()
     };
-    let quote = sp.quote_rev_deposit_stake_unchecked(50, 100).unwrap();
+    let quote = sp
+        .quote_rev_deposit_stake_unchecked(QuoteRevDepositStakeArgs {
+            tokens_out: 50,
+            unstaked_lamports: Some(100),
+        })
+        .unwrap();
 
     assert_eq!(quote.stake_account_lamports_in.staked, 0);
     assert_eq!(quote.stake_account_lamports_in.unstaked, 100);
@@ -113,5 +246,10 @@ fn quote_rev_deposit_stake_full_stake_fee_without_unstaked_cover_returns_none() 
         ..Default::default()
     };
 
-    assert!(sp.quote_rev_deposit_stake_unchecked(101, 100).is_none());
+    assert!(sp
+        .quote_rev_deposit_stake_unchecked(QuoteRevDepositStakeArgs {
+            tokens_out: 101,
+            unstaked_lamports: Some(100),
+        })
+        .is_none());
 }

--- a/core/tests/tests/quote/deposit_stake.rs
+++ b/core/tests/tests/quote/deposit_stake.rs
@@ -52,28 +52,7 @@ fn quote_rev_deposit_stake_zero_fee_direct_path() {
 }
 
 #[test]
-fn quote_rev_deposit_stake_unstaked_lamports_already_cover_target() {
-    let sp = StakePool {
-        total_lamports: 1_000_000_000,
-        pool_token_supply: 1_000_000_000,
-        stake_deposit_fee: Fee::ZERO,
-        sol_deposit_fee: Fee::ZERO,
-        ..Default::default()
-    };
-    let requested = 1_000_000;
-    let unstaked = 2_282_880;
-
-    let quote = sp
-        .quote_rev_deposit_stake_unchecked(requested, unstaked)
-        .unwrap();
-
-    assert_eq!(quote.stake_account_lamports_in.staked, 0);
-    assert_eq!(quote.stake_account_lamports_in.unstaked, unstaked);
-    assert_sufficient_and_minimal(&sp, quote, requested);
-}
-
-#[test]
-fn quote_rev_deposit_stake_binary_search_path_with_nonzero_fees() {
+fn quote_rev_deposit_stake_nonzero_fees_returns_none() {
     let sp = StakePool {
         total_lamports: 1_000_000_000_000,
         pool_token_supply: 900_000_000_000,
@@ -85,17 +64,9 @@ fn quote_rev_deposit_stake_binary_search_path_with_nonzero_fees() {
             numerator: 7,
             denominator: 1_000,
         },
-        stake_referral_fee: 20,
         ..Default::default()
     };
-    let requested = 90_000_000;
-    let unstaked = 2_282_880;
-
-    let quote = sp
-        .quote_rev_deposit_stake_unchecked(requested, unstaked)
-        .unwrap();
-
-    assert_eq!(quote.stake_account_lamports_in.unstaked, unstaked);
-    assert!(quote.manager_fee > 0);
-    assert_sufficient_and_minimal(&sp, quote, requested);
+    assert!(sp
+        .quote_rev_deposit_stake_unchecked(90_000_000, 2_282_880)
+        .is_none());
 }

--- a/core/tests/tests/quote/deposit_stake.rs
+++ b/core/tests/tests/quote/deposit_stake.rs
@@ -52,7 +52,7 @@ fn quote_rev_deposit_stake_zero_fee_direct_path() {
 }
 
 #[test]
-fn quote_rev_deposit_stake_nonzero_fees_returns_none() {
+fn quote_rev_deposit_stake_nonzero_fees_returns_sufficient_quote() {
     let sp = StakePool {
         total_lamports: 1_000_000_000_000,
         pool_token_supply: 900_000_000_000,
@@ -66,7 +66,52 @@ fn quote_rev_deposit_stake_nonzero_fees_returns_none() {
         },
         ..Default::default()
     };
-    assert!(sp
-        .quote_rev_deposit_stake_unchecked(90_000_000, 2_282_880)
-        .is_none());
+    let requested = 90_000_000;
+    let unstaked = 2_282_880;
+
+    let quote = sp
+        .quote_rev_deposit_stake_unchecked(requested, unstaked)
+        .unwrap();
+
+    assert_eq!(quote.stake_account_lamports_in.unstaked, unstaked);
+    assert_eq!(
+        sp.quote_deposit_stake_unchecked(quote.stake_account_lamports_in),
+        Some(quote)
+    );
+    assert!(quote.tokens_out >= requested);
+}
+
+#[test]
+fn quote_rev_deposit_stake_when_unstaked_covers_target_returns_zero_staked() {
+    let sp = StakePool {
+        total_lamports: 1_000_000_000,
+        pool_token_supply: 1_000_000_000,
+        stake_deposit_fee: Fee {
+            numerator: 1,
+            denominator: 1,
+        },
+        sol_deposit_fee: Fee::ZERO,
+        ..Default::default()
+    };
+    let quote = sp.quote_rev_deposit_stake_unchecked(50, 100).unwrap();
+
+    assert_eq!(quote.stake_account_lamports_in.staked, 0);
+    assert_eq!(quote.stake_account_lamports_in.unstaked, 100);
+    assert!(quote.tokens_out >= 50);
+}
+
+#[test]
+fn quote_rev_deposit_stake_full_stake_fee_without_unstaked_cover_returns_none() {
+    let sp = StakePool {
+        total_lamports: 1_000_000_000,
+        pool_token_supply: 1_000_000_000,
+        stake_deposit_fee: Fee {
+            numerator: 1,
+            denominator: 1,
+        },
+        sol_deposit_fee: Fee::ZERO,
+        ..Default::default()
+    };
+
+    assert!(sp.quote_rev_deposit_stake_unchecked(101, 100).is_none());
 }

--- a/core/tests/tests/quote/deposit_stake.rs
+++ b/core/tests/tests/quote/deposit_stake.rs
@@ -1,0 +1,101 @@
+use sanctum_spl_stake_pool_core::{DepositStakeQuote, Fee, StakeAccountLamports, StakePool};
+
+fn assert_sufficient_and_minimal(sp: &StakePool, quote: DepositStakeQuote, requested: u64) {
+    assert_eq!(
+        sp.quote_deposit_stake_unchecked(quote.stake_account_lamports_in),
+        Some(quote)
+    );
+    assert!(
+        quote.tokens_out >= requested,
+        "{} < {}",
+        quote.tokens_out,
+        requested
+    );
+
+    if quote.stake_account_lamports_in.staked == 0 {
+        return;
+    }
+
+    let previous = StakeAccountLamports {
+        staked: quote.stake_account_lamports_in.staked - 1,
+        unstaked: quote.stake_account_lamports_in.unstaked,
+    };
+    if let Some(previous_quote) = sp.quote_deposit_stake_unchecked(previous) {
+        assert!(
+            previous_quote.tokens_out < requested,
+            "previous staked lamports still satisfied target: {:?}",
+            previous_quote
+        );
+    }
+}
+
+#[test]
+fn quote_rev_deposit_stake_zero_fee_direct_path() {
+    let sp = StakePool {
+        total_lamports: 1_000_000_000_000,
+        pool_token_supply: 900_000_000_000,
+        stake_deposit_fee: Fee::ZERO,
+        sol_deposit_fee: Fee::ZERO,
+        ..Default::default()
+    };
+    let requested = 90_000_000;
+    let unstaked = 2_282_880;
+
+    let quote = sp
+        .quote_rev_deposit_stake_unchecked(requested, unstaked)
+        .unwrap();
+
+    assert_eq!(quote.stake_account_lamports_in.unstaked, unstaked);
+    assert_eq!(quote.manager_fee, 0);
+    assert_eq!(quote.referral_fee, 0);
+    assert_sufficient_and_minimal(&sp, quote, requested);
+}
+
+#[test]
+fn quote_rev_deposit_stake_unstaked_lamports_already_cover_target() {
+    let sp = StakePool {
+        total_lamports: 1_000_000_000,
+        pool_token_supply: 1_000_000_000,
+        stake_deposit_fee: Fee::ZERO,
+        sol_deposit_fee: Fee::ZERO,
+        ..Default::default()
+    };
+    let requested = 1_000_000;
+    let unstaked = 2_282_880;
+
+    let quote = sp
+        .quote_rev_deposit_stake_unchecked(requested, unstaked)
+        .unwrap();
+
+    assert_eq!(quote.stake_account_lamports_in.staked, 0);
+    assert_eq!(quote.stake_account_lamports_in.unstaked, unstaked);
+    assert_sufficient_and_minimal(&sp, quote, requested);
+}
+
+#[test]
+fn quote_rev_deposit_stake_binary_search_path_with_nonzero_fees() {
+    let sp = StakePool {
+        total_lamports: 1_000_000_000_000,
+        pool_token_supply: 900_000_000_000,
+        stake_deposit_fee: Fee {
+            numerator: 3,
+            denominator: 1_000,
+        },
+        sol_deposit_fee: Fee {
+            numerator: 7,
+            denominator: 1_000,
+        },
+        stake_referral_fee: 20,
+        ..Default::default()
+    };
+    let requested = 90_000_000;
+    let unstaked = 2_282_880;
+
+    let quote = sp
+        .quote_rev_deposit_stake_unchecked(requested, unstaked)
+        .unwrap();
+
+    assert_eq!(quote.stake_account_lamports_in.unstaked, unstaked);
+    assert!(quote.manager_fee > 0);
+    assert_sufficient_and_minimal(&sp, quote, requested);
+}

--- a/core/tests/tests/quote/deposit_stake.rs
+++ b/core/tests/tests/quote/deposit_stake.rs
@@ -1,26 +1,12 @@
+use expect_test::expect;
 use proptest::prelude::*;
-use sanctum_spl_stake_pool_core::{
-    DepositStakeQuote, Fee, QuoteRevDepositStakeArgs, StakeAccountLamports, StakePool,
-};
+use sanctum_spl_stake_pool_core::{Fee, QuoteRevDepositStakeArgs, StakeAccountLamports, StakePool};
 use sanctum_u64_ratio::Ratio;
 
 use crate::common::{
     proptest_utils::{ratio_gte_one, ratio_lte_one},
     quote::{NewPoolQuoteU64sBuilder, PoolQuoteU64Ds},
 };
-
-fn assert_sufficient(sp: &StakePool, quote: DepositStakeQuote, requested: u64) {
-    assert_eq!(
-        sp.quote_deposit_stake_unchecked(quote.stake_account_lamports_in),
-        Some(quote)
-    );
-    assert!(
-        quote.tokens_out >= requested,
-        "{} < {}",
-        quote.tokens_out,
-        requested
-    );
-}
 
 fn quote_rev_deposit_stake_round_trip(
     pool: PoolQuoteU64Ds,
@@ -29,12 +15,6 @@ fn quote_rev_deposit_stake_round_trip(
     stake_deposit_fee: Fee,
     sol_deposit_fee: Fee,
 ) {
-    // to_fee_ceil() returns None for fees > 100%, which the reverse requires
-    // but the forward does not. Skip those cases rather than treating None as a bug
-    if stake_deposit_fee.to_fee_ceil().is_none() || sol_deposit_fee.to_fee_ceil().is_none() {
-        return;
-    }
-
     let sp = StakePool {
         total_lamports: *pool.total_lamports(),
         pool_token_supply: *pool.pool_token_supply(),
@@ -56,7 +36,52 @@ fn quote_rev_deposit_stake_round_trip(
         .expect("reverse returned None but forward succeeded with valid fees");
 
     assert_eq!(rev.stake_account_lamports_in.unstaked, unstaked);
-    assert_sufficient(&sp, rev, forward.tokens_out);
+    assert_eq!(
+        sp.quote_deposit_stake_unchecked(rev.stake_account_lamports_in),
+        Some(rev)
+    );
+    assert!(
+        rev.tokens_out >= forward.tokens_out,
+        "{} < {}",
+        rev.tokens_out,
+        forward.tokens_out
+    );
+    // `sol_lo` conservative estimate can overshoot by 1 pool token.
+    // For `ratio_lte_one` pools (supply > total), `rev_lamports_to_pool_tokens` can
+    // additionally overshoot by floor(supply/total) pool tokens for skipped values.
+    // Each extra pool token adds at most 1 to `staked_after_fee`, so total bound is:
+    // `forward.tokens_out + floor(supply/total) + 1`
+    let pool_token_overshoot = sp.pool_token_supply / sp.total_lamports.max(1);
+    assert!(
+        rev.tokens_out <= forward.tokens_out.saturating_add(pool_token_overshoot + 1),
+        "rev.tokens_out={} > bound={} (forward.tokens_out={}, pool_token_overshoot={})",
+        rev.tokens_out,
+        forward.tokens_out.saturating_add(pool_token_overshoot + 1),
+        forward.tokens_out,
+        pool_token_overshoot,
+    );
+
+    // maps that 1 pool token gap bound to staked lamports after fees
+    let fee_sub = stake_deposit_fee
+        .denominator
+        .saturating_sub(stake_deposit_fee.numerator);
+    let fee_amplifier = if fee_sub == 0 {
+        1u64
+    } else {
+        stake_deposit_fee.denominator.div_ceil(fee_sub)
+    };
+    let lamports_per_token = sp.total_lamports.div_ceil(sp.pool_token_supply.max(1));
+    let staked_bound = forward
+        .stake_account_lamports_in
+        .staked
+        .saturating_add(fee_amplifier.saturating_mul(lamports_per_token));
+    assert!(
+        rev.stake_account_lamports_in.staked <= staked_bound,
+        "rev.staked={} > staked_bound={} (forward.staked={}",
+        rev.stake_account_lamports_in.staked,
+        staked_bound,
+        forward.stake_account_lamports_in.staked,
+    );
 }
 
 // verifies the floor arithmetic bound relied on by `quote_rev_deposit_stake_unchecked`:
@@ -115,11 +140,8 @@ fn assert_unstaked_token_bucket_bound(
 
 proptest! {
     #[test]
-    fn quote_rev_deposit_stake_round_trip_x_gte_1_pt(
-        Ratio {
-            n: total_lamports,
-            d: pool_token_supply,
-        } in ratio_gte_one(),
+    fn quote_rev_deposit_stake_round_trip_prop(
+        (r_gte, r_lte) in (ratio_gte_one(), ratio_lte_one()),
         staked: u64,
         unstaked: u64,
         stake_fee_n: u64,
@@ -127,85 +149,37 @@ proptest! {
         sol_fee_n: u64,
         sol_fee_d: u64,
     ) {
-        quote_rev_deposit_stake_round_trip(
-            NewPoolQuoteU64sBuilder::start()
-                .with_total_lamports(total_lamports)
-                .with_pool_token_supply(pool_token_supply)
-                .build(),
-            staked,
-            unstaked,
-            Fee { numerator: stake_fee_n, denominator: stake_fee_d },
-            Fee { numerator: sol_fee_n, denominator: sol_fee_d },
-        );
+        let stake_fee = Fee { numerator: stake_fee_n, denominator: stake_fee_d };
+        let sol_fee = Fee { numerator: sol_fee_n, denominator: sol_fee_d };
+        for Ratio { n: total_lamports, d: pool_token_supply } in [r_gte, r_lte] {
+            quote_rev_deposit_stake_round_trip(
+                NewPoolQuoteU64sBuilder::start()
+                    .with_total_lamports(total_lamports)
+                    .with_pool_token_supply(pool_token_supply)
+                    .build(),
+                staked, unstaked, stake_fee, sol_fee,
+            );
+        }
     }
 
     #[test]
-    fn quote_rev_deposit_stake_round_trip_x_lte_1_pt(
-        Ratio {
-            n: total_lamports,
-            d: pool_token_supply,
-        } in ratio_lte_one(),
-        staked: u64,
-        unstaked: u64,
-        stake_fee_n: u64,
-        stake_fee_d: u64,
-        sol_fee_n: u64,
-        sol_fee_d: u64,
-    ) {
-        quote_rev_deposit_stake_round_trip(
-            NewPoolQuoteU64sBuilder::start()
-                .with_total_lamports(total_lamports)
-                .with_pool_token_supply(pool_token_supply)
-                .build(),
-            staked,
-            unstaked,
-            Fee { numerator: stake_fee_n, denominator: stake_fee_d },
-            Fee { numerator: sol_fee_n, denominator: sol_fee_d },
-        );
-    }
-
-    #[test]
-    fn deposit_stake_unstaked_token_bucket_bound_x_gte_1_pt(
-        Ratio {
-            n: total_lamports,
-            d: pool_token_supply,
-        } in ratio_gte_one(),
+    fn deposit_stake_unstaked_token_bucket_bound(
+        (r_gte, r_lte) in (ratio_gte_one(), ratio_lte_one()),
         staked: u64,
         unstaked: u64,
         sol_fee_n: u64,
         sol_fee_d: u64,
     ) {
-        assert_unstaked_token_bucket_bound(
-            NewPoolQuoteU64sBuilder::start()
-                .with_total_lamports(total_lamports)
-                .with_pool_token_supply(pool_token_supply)
-                .build(),
-            staked,
-            unstaked,
-            Fee { numerator: sol_fee_n, denominator: sol_fee_d },
-        );
-    }
-
-    #[test]
-    fn deposit_stake_unstaked_token_bucket_bound_x_lte_1_pt(
-        Ratio {
-            n: total_lamports,
-            d: pool_token_supply,
-        } in ratio_lte_one(),
-        staked: u64,
-        unstaked: u64,
-        sol_fee_n: u64,
-        sol_fee_d: u64,
-    ) {
-        assert_unstaked_token_bucket_bound(
-            NewPoolQuoteU64sBuilder::start()
-                .with_total_lamports(total_lamports)
-                .with_pool_token_supply(pool_token_supply)
-                .build(),
-            staked,
-            unstaked,
-            Fee { numerator: sol_fee_n, denominator: sol_fee_d },
-        );
+        let sol_fee = Fee { numerator: sol_fee_n, denominator: sol_fee_d };
+        for Ratio { n: total_lamports, d: pool_token_supply } in [r_gte, r_lte] {
+            assert_unstaked_token_bucket_bound(
+                NewPoolQuoteU64sBuilder::start()
+                    .with_total_lamports(total_lamports)
+                    .with_pool_token_supply(pool_token_supply)
+                    .build(),
+                staked, unstaked, sol_fee,
+            );
+        }
     }
 }
 
@@ -228,9 +202,18 @@ fn quote_rev_deposit_stake_when_unstaked_covers_target_returns_zero_staked() {
         })
         .unwrap();
 
-    assert_eq!(quote.stake_account_lamports_in.staked, 0);
-    assert_eq!(quote.stake_account_lamports_in.unstaked, 100);
-    assert!(quote.tokens_out >= 50);
+    expect![[r#"
+        DepositStakeQuote {
+            stake_account_lamports_in: StakeAccountLamports {
+                staked: 0,
+                unstaked: 100,
+            },
+            tokens_out: 100,
+            manager_fee: 0,
+            referral_fee: 0,
+        }
+    "#]]
+    .assert_debug_eq(&quote);
 }
 
 #[test]

--- a/core/tests/tests/quote/mod.rs
+++ b/core/tests/tests/quote/mod.rs
@@ -1,2 +1,3 @@
+mod deposit_stake;
 mod withdraw_sol;
 mod withdraw_stake;

--- a/ts/sdk/src/state/pool.rs
+++ b/ts/sdk/src/state/pool.rs
@@ -1,6 +1,6 @@
 use sanctum_spl_stake_pool_core::{
-    AccountType, DepositSolQuote, DepositStakeQuote, Fee, FutureEpoch, StakeAccountLamports,
-    WithdrawSolQuote, WithdrawStakeQuote,
+    AccountType, DepositSolQuote, DepositStakeQuote, Fee, FutureEpoch, QuoteRevDepositStakeArgs,
+    StakeAccountLamports, WithdrawSolQuote, WithdrawStakeQuote,
 };
 use serde::{Deserialize, Serialize};
 use tsify_next::Tsify;
@@ -73,7 +73,10 @@ pub fn quote_rev_deposit_stake(
     unstaked_lamports: u64,
 ) -> Result<DepositStakeQuote, JsError> {
     this.0
-        .quote_rev_deposit_stake_unchecked(tokens_out, unstaked_lamports)
+        .quote_rev_deposit_stake_unchecked(QuoteRevDepositStakeArgs {
+            tokens_out,
+            unstaked_lamports: Some(unstaked_lamports),
+        })
         .ok_or_else(arithmetic_overflow_err)
 }
 

--- a/ts/sdk/src/state/pool.rs
+++ b/ts/sdk/src/state/pool.rs
@@ -66,6 +66,18 @@ pub fn quote_deposit_stake(
 }
 
 /// @throws on arithmetic overflow
+#[wasm_bindgen(js_name = quoteRevDepositStake)]
+pub fn quote_rev_deposit_stake(
+    this: &StakePoolHandle,
+    tokens_out: u64,
+    unstaked_lamports: u64,
+) -> Result<DepositStakeQuote, JsError> {
+    this.0
+        .quote_rev_deposit_stake_unchecked(tokens_out, unstaked_lamports)
+        .ok_or_else(arithmetic_overflow_err)
+}
+
+/// @throws on arithmetic overflow
 #[wasm_bindgen(js_name = quoteWithdrawSol)]
 pub fn quote_withdraw_sol(
     this: &StakePoolHandle,

--- a/ts/tests/test/deposit-withdraw-local.test.ts
+++ b/ts/tests/test/deposit-withdraw-local.test.ts
@@ -65,7 +65,6 @@ describe("picosol-quote-sim-local", async () => {
       address(accountJson.pubkey)
     );
 
-    // quoteRevDepositStake only supports zero deposit fees
     setStakePool(stakePoolHandle, {
       ...getStakePool(stakePoolHandle),
       stakeDepositFee: { numerator: 0n, denominator: 0n },
@@ -83,12 +82,8 @@ describe("picosol-quote-sim-local", async () => {
       reverseQuote.stakeAccountLamportsIn
     );
 
-    assert.strictEqual(
-      reverseQuote.stakeAccountLamportsIn.unstaked,
-      DEPOSIT_STAKE_LAMPORTS.unstaked
-    );
-    assert(reverseQuote.tokensOut >= quote.tokensOut);
-    assert.strictEqual(reverseForwardQuote.tokensOut, reverseQuote.tokensOut);
+    assert.deepStrictEqual(reverseQuote, quote);
+    assert.deepStrictEqual(reverseForwardQuote, quote);
   });
 
   it.sequential("deposit-sol", async () => {

--- a/ts/tests/test/deposit-withdraw-local.test.ts
+++ b/ts/tests/test/deposit-withdraw-local.test.ts
@@ -52,7 +52,7 @@ describe("picosol-quote-sim-local", async () => {
   // For some reason the first sequential test always take a long time
   // ~10s to complete, regardless of which user action it is (deposit/withdraw sol/stake)
 
-  it("quoteRevDepositStake roundtrip", async () => {
+  it.sequential("quoteRevDepositStake roundtrip", async () => {
     const DEPOSIT_STAKE_LAMPORTS = {
       staked: 100_000_000_000n,
       unstaked: 2282880n,

--- a/ts/tests/test/deposit-withdraw-local.test.ts
+++ b/ts/tests/test/deposit-withdraw-local.test.ts
@@ -13,6 +13,7 @@ import {
   initSyncEmbed,
   quoteDepositSol,
   quoteDepositStake,
+  quoteRevDepositStake,
   quoteWithdrawSol,
   quoteWithdrawStake,
   withdrawSolIxFromStakePool,
@@ -49,6 +50,38 @@ initSyncEmbed();
 describe("picosol-quote-sim-local", async () => {
   // For some reason the first sequential test always take a long time
   // ~10s to complete, regardless of which user action it is (deposit/withdraw sol/stake)
+
+  it("quoteRevDepositStake roundtrip", async () => {
+    const DEPOSIT_STAKE_LAMPORTS = {
+      staked: 100_000_000_000n,
+      unstaked: 2282880n,
+    };
+
+    const rpcClient = createSolanaRpc("http://localhost:8899");
+    const accountJson = readTestFixturesJsonFile("picosol-stake-pool");
+    const stakePoolHandle = await fetchStakePool(
+      rpcClient,
+      address(accountJson.pubkey)
+    );
+
+    const quote = quoteDepositStake(stakePoolHandle, DEPOSIT_STAKE_LAMPORTS);
+    const reverseQuote = quoteRevDepositStake(
+      stakePoolHandle,
+      quote.tokensOut,
+      DEPOSIT_STAKE_LAMPORTS.unstaked
+    );
+    const reverseForwardQuote = quoteDepositStake(
+      stakePoolHandle,
+      reverseQuote.stakeAccountLamportsIn
+    );
+
+    assert.strictEqual(
+      reverseQuote.stakeAccountLamportsIn.unstaked,
+      DEPOSIT_STAKE_LAMPORTS.unstaked
+    );
+    assert(reverseQuote.tokensOut >= quote.tokensOut);
+    assert.strictEqual(reverseForwardQuote.tokensOut, reverseQuote.tokensOut);
+  });
 
   it.sequential("deposit-sol", async () => {
     const keypair = await readTestFixturesKeypair("signer");

--- a/ts/tests/test/deposit-withdraw-local.test.ts
+++ b/ts/tests/test/deposit-withdraw-local.test.ts
@@ -16,6 +16,7 @@ import {
   quoteRevDepositStake,
   quoteWithdrawSol,
   quoteWithdrawStake,
+  setStakePool,
   withdrawSolIxFromStakePool,
   withdrawStakeIxFromStakePool,
 } from "@sanctumso/spl-stake-pool";
@@ -63,6 +64,13 @@ describe("picosol-quote-sim-local", async () => {
       rpcClient,
       address(accountJson.pubkey)
     );
+
+    // quoteRevDepositStake only supports zero deposit fees
+    setStakePool(stakePoolHandle, {
+      ...getStakePool(stakePoolHandle),
+      stakeDepositFee: { numerator: 0n, denominator: 0n },
+      solDepositFee: { numerator: 0n, denominator: 0n },
+    });
 
     const quote = quoteDepositStake(stakePoolHandle, DEPOSIT_STAKE_LAMPORTS);
     const reverseQuote = quoteRevDepositStake(


### PR DESCRIPTION
Add new method quote_rev_deposit_stake() that given a desired number of pool tokens out from a DepositStake, returns the minimum staked lamports the stake account must hold to achieve that output, given a fixed unstaked_lamports amount

For zero deposit fees, this returns the exact minimum staked lamports.

Otherwise, function computes minimum staked lamports the value of `unstaked_lamports` as a conservative lower bound for the unstaked contribution. 
This may overestimate because it ignores combined `staked + unstaked` rounding.
The overestimate is at most the staked lamports needed for one pool-token base unit after stake fees